### PR TITLE
Add Sample C++ Problem Test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,3 +45,13 @@ jobs:
 
       - name: Test Package
         run: corepack yarn test
+
+  test-sample:
+    name: Test Sample
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Test Sample Problems
+        run: sample/test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.eslint*
 !.git*
 
+build/
 coverage/
 dist/
 node_modules/

--- a/sample/problems/2235/solution.cpp
+++ b/sample/problems/2235/solution.cpp
@@ -1,0 +1,4 @@
+class Solution {
+ public:
+  int sum(int num1, int num2) { return num1 + num2; }
+};

--- a/sample/problems/2235/test.cpp
+++ b/sample/problems/2235/test.cpp
@@ -1,0 +1,28 @@
+#include <iostream>
+#include <tuple>
+#include <vector>
+
+#include "solution.cpp"
+
+struct TestCase {
+  const char *name;
+  std::tuple<int, int> inputs;
+  int output;
+};
+
+std::vector<TestCase> test_cases{
+    {.name = "example 1", .inputs{12, 5}, .output = 17},
+    {.name = "example 2", .inputs{-10, 4}, .output = -6}};
+
+int main() {
+  for (const auto &t : test_cases) {
+    std::cout << "Testing " << t.name << "...\n";
+    Solution s{};
+    auto output = s.sum(std::get<0>(t.inputs), std::get<1>(t.inputs));
+    if (output != t.output) {
+      std::cerr << "Wrong output: " << output << " != " << t.output << " \n";
+      return 1;
+    }
+  }
+  return 0;
+}

--- a/sample/test.sh
+++ b/sample/test.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+cd "$(dirname "$0")"
+for test in **/*/test.cpp; do
+  mkdir -p "build/$test"
+
+  echo "Compiling $test"
+  clang++ --std=c++20 "$test" -o "build/${test%.*}"
+
+  echo "Running build/${test%.*}"
+  build/${test%.*}
+done


### PR DESCRIPTION
This pull request resolves #4 by introducing the following changes:
- Adding a C++ sample that tests the solution for problem [2235. Add Two Integers](https://leetcode.com/problems/add-two-integers/).
- Adding a simple `test.sh` script for compiling and running sample tests.
- Adding a `test-sample` job in the `test.yaml` workflow for compiling and running sample tests in the CI.